### PR TITLE
Update maximum pack format for resource/datapacks

### DIFF
--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -17,7 +17,7 @@
           "description": "A version for the current pack\nhttps://minecraft.wiki/w/Data_pack#Contents",
           "type": "integer",
           "minimum": 1,
-          "maximum": 18,
+          "maximum": 34,
           "default": 4
         }
       },


### PR DESCRIPTION
The Pack-Format now supports up to 28 (resourcepacks) or 34 (datapacks) for the current game snapshot. See https://minecraft.wiki/w/Pack_format#List_of_resource_pack_formats and https://minecraft.wiki/w/Pack_format#List_of_data_pack_formats for reference

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
